### PR TITLE
Fix Attribute error, add new attribute 'file'

### DIFF
--- a/pastemyst/models/language.py
+++ b/pastemyst/models/language.py
@@ -4,7 +4,7 @@ from pastemyst.utils import spacify_string
 class LanguageInfo(object):
     __slots__ = (
         'ext', 'name', 'color',
-        'mode', 'mimes'
+        'mode', 'mimes', 'file'
     )
 
     def from_dict(self, data):


### PR DESCRIPTION
Fix the attribute error thrown while fetching a LanguageInfo object ( #2 )

- Add new `file` attribute

#### Tests

- [x] Tests are passing after this modification.

##### Sample tests
```py
print(client.get_language_info(ext="py").name)
```
##### Output
```
Python
```
![image](https://user-images.githubusercontent.com/70792552/111902573-21997580-8a64-11eb-88cc-457b527b0be7.png)
